### PR TITLE
Rename SDC references to Triton

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ formal writing that it has come to represent.)
 | -------- | ------------------------------------------------------------- |
 | publish  | [RFD 1 Triton Container Naming Service](./rfd/0001/README.md) |
 | publish  | [RFD 2 Docker Logging in SDC](./rfd/0002/README.md) |
-| draft    | [RFD 3 SDC Compute Nodes Reboot](./rfd/0003/README.md) |
+| draft    | [RFD 3 Triton Compute Nodes Reboot](./rfd/0003/README.md) |
 | draft    | [RFD 4 Docker Build Implementation For Triton](./rfd/0004/README.md) |
 | publish  | [RFD 5 Triton Change Feed Support](./rfd/0005/README.md) |
-| draft    | [RFD 6 Improving SDC and Manta RAS Infrastructure](./rfd/0006/README.md) |
+| draft    | [RFD 6 Improving Triton and Manta RAS Infrastructure](./rfd/0006/README.md) |
 | draft    | [RFD 7 Datalink LLDP and State Tracking](./rfd/0007/README.md) |
 | publish  | [RFD 9 sdcadm fabrics management](./rfd/0009/README.md) |
 | publish  | [RFD 10 Sending GZ Docker Logs to Manta](./rfd/0010/README.md) |
-| draft    | [RFD 11 IPv6 and multiple IP addresses support in SDC](./rfd/0011/README.md) |
+| draft    | [RFD 11 IPv6 and multiple IP addresses support in Triton](./rfd/0011/README.md) |
 | draft    | [RFD 12 Bedtime for node-smartdc](./rfd/0012/README.md) |
 | draft    | [RFD 13 RBAC v2 for Improved Organization and Docker RBAC Support](./rfd/0013/README.md) |
 | draft    | [RFD 14 Signed ZFS Send](./rfd/0014/README.md) |
@@ -63,15 +63,15 @@ formal writing that it has come to represent.)
 | predraft | [RFD 19 Versioning For Workflow Modules](./rfd/0019/README.md) |
 | predraft | [RFD 18 Support for using labels to select networks and packages](./rfd/0018/README.md) |
 | draft    | [RFD 20 Manta Slop-Aware Zone Scheduling](./rfd/0020/README.md) |
-| draft    | [RFD 21 Metadata Scrubber For SDC](./rfd/0021/README.md) |
+| draft    | [RFD 21 Metadata Scrubber For Triton](./rfd/0021/README.md) |
 | draft    | [RFD 22 Improved user experience after a request has failed](./rfd/0022/README.md) |
 | draft    | [RFD 23 A plan for Manta docs](./rfd/0023/README.md) |
 | predraft | [RFD 24 Designation API improvements to facilitate platform update](./rfd/0024/README.md) |
 | draft    | [RFD 25 Pluralizing CloudAPI CreateMachine et al](./rfd/0025/README.md) |
-| draft    | [RFD 26 Network Shared Storage for SDC](./rfd/0026/README.md) |
+| draft    | [RFD 26 Network Shared Storage for Triton](./rfd/0026/README.md) |
 | publish  | [RFD 27 Triton Container Monitor](./rfd/0027/README.md) |
 | predraft | [RFD 28 Improving syncing between Compute Nodes and NAPI](./rfd/0028/README.md) |
-| draft    | [RFD 29 Nothing in SDC should rely on ur outside bootstrapping and emergencies](./rfd/0029/README.md) |
+| draft    | [RFD 29 Nothing in Triton should rely on ur outside bootstrapping and emergencies](./rfd/0029/README.md) |
 | predraft | [RFD 30 Handling "lastexited" for zones when CN is rebooted or crashes](./rfd/0030/README.md) |
 | draft    | [RFD 31 libscsi and uscsi(7I) Improvements for Firmware Upgrade](./rfd/0031/README.md)
 | draft    | [RFD 32 Multiple IP Addresses in NAPI](./rfd/0032/README.md) |
@@ -176,7 +176,7 @@ need to be taken or do certain updates need to happen together for this
 What (untrusted) user input (including both data and code) will be used as part
 of the change?  Which components will interact with that input?  How will that
 input be validated and managed securely?  What new operations are exposed and
-which privileges will they require (both system privileges and SDC privileges)?
+which privileges will they require (both system privileges and Triton privileges)?
 How would an attacker use the proposed facilities to escalate their privileges?
 
 
@@ -266,8 +266,8 @@ your work. The options are:
 * [smartos-discuss@lists.smartos.org](https://www.listbox.com/member/archive/184463/=now)
 
 The subject of the message should be the RFD number and synopsis. For
-example, if you RFD number 169 with the title  Overlay Networks for SDC,
-then the subject would be `RFD 169 Overlay Networks for SDC`.
+example, if you RFD number 169 with the title  Overlay Networks for Triton,
+then the subject would be `RFD 169 Overlay Networks for Triton`.
 
 In the body, make sure to include a link to the RFD.
 
@@ -289,7 +289,7 @@ should consider creating a new RFD.
 
 Contributions are welcome, you do not have to be a Joyent employee to
 submit an RFD or to comment on one. The discussions for RFDs happen on
-the open on the various mailing lists related to SDC, Manta, and
+the open on the various mailing lists related to Triton, Manta, and
 SmartOS.
 
 To submit a new RFD, please provide a git patch or a pull request that

--- a/rfd/0003/README.md
+++ b/rfd/0003/README.md
@@ -14,18 +14,18 @@ state: draft
     Copyright 2015 Joyent Inc.
 -->
 
-# RFD 3 SDC Compute Nodes Reboot
+# RFD 3 Triton Compute Nodes Reboot
 
 ## Introduction
 
 A new `sdcadm experimental reboot-plan` collection of commands (unpromised
 interface) for working towards controlled and safe reboots of selected
-servers in a typical SDC setup.
+servers in a typical Triton (formerly SmartDataCenter or SDC) setup.
 
-One of the least specified and hardest parts of SDC upgrades right now is
+One of the least specified and hardest parts of Triton upgrades right now is
 managing the reboots of CNs and the headnode safely. In particular:
 
-- controlling reboots of the "core" servers (those with SDC core components,
+- controlling reboots of the "core" servers (those with Triton core components,
   esp. the HA binders and manatees)
 - reasonably helpful tooling for rebooting (subsets of) the other servers in a
   DC: rolling reboots, reboot rates
@@ -39,9 +39,9 @@ The list of desired subcommands should be able to handle:
 
 ## Terminology
 
-### How is a server reboot executed in SDC?
+### How is a server reboot executed in Triton?
 
-In order to reboot a SDC server, we execute the following CNAPI request
+In order to reboot a Triton server, we execute the following CNAPI request
 
     sdc-cnapi /servers/<UUID>/reboot -X POST
 
@@ -97,7 +97,7 @@ for completion of the reboot of each server.
 Execution of the reboot plan consists of the creation of the plan, queuing
 of the different servers to reboot at the provided concurrency, and the
 verification of the server reboot, either through CNAPI for servers not hosting
-core SDC components, or through a manatee instance for servers hosting core
+core Triton components, or through a manatee instance for servers hosting core
 components.
 
 ### Creation, modification and retrieval of the reboot plan information:
@@ -130,16 +130,16 @@ continue with that one or, optionally, ask the user to cancel such plan before
 attempting the execution of a new one (TBD).
 
 Once the new plan is created, this process will begin either with the reboot
-of the first core server, when dealing with CNs hosting SDC core components,
+of the first core server, when dealing with CNs hosting Triton core components,
 or with the reboot of the first batch of CNs not hosting core components.
 
 The process will first check `Workflow API` to verify that the reboot jobs
 have been successfully created and executed, and then will poll either `CNAPI`
 for reboot status of CNs, or use `manatee-adm` to check for the state of
-the manatee SDC shard when rebooting CNs with core components.
+the manatee Triton shard when rebooting CNs with core components.
 
-This routine will be repeated until all the CNs hosting SDC core members have
-been rebooted, or until we complete the reboot of all the CNs not hosting SDC
+This routine will be repeated until all the CNs hosting Triton core members have
+been rebooted, or until we complete the reboot of all the CNs not hosting Triton
 core instances, at the provided concurrency.
 
 As specified above, every time a server reboot has been completed, the process
@@ -152,11 +152,11 @@ using a sequence established by manatee's shard administration. The main
 problem would be to keep track of the reboot of these core CNs in terms of
 how long it took to reboot each one of these nodes and, of course, if we
 drive such CNs from the `sdcadm` process itself, we will not be able to
-_schedule_ reboot of CNs hosting core SDC components. Which I'd say has sense,
+_schedule_ reboot of CNs hosting core Triton components. Which I'd say has sense,
 since a failure in the reboot of these CNs will likely compromise the state
-of the whole SDC setup and, therefore, should be an attended operation.
+of the whole Triton setup and, therefore, should be an attended operation.
 
-The proposed solution is to always reboot first `CNs` hosting any SDC core
+The proposed solution is to always reboot first `CNs` hosting any Triton core
 component - even if those are not members of a manatee shard, or binder's
 cluster of ZooKeepers - for example, an imgapi instance.
 
@@ -209,7 +209,7 @@ the subcommands in charge of creating the reboot processes the ability to check
 if there's a reboot command not yet finished for the cases when the `sdcadm`
 process exits during the course of the reboot process.
 
-That's to say: if we issue `sdcadm reboot --concurrency=10` to an SDC
+That's to say: if we issue `sdcadm reboot --concurrency=10` to an Triton
 setup with 30 servers, and the `sdcadm` process exits in the middle of the
 reboots, we should make sure that the next invocation of this command,
 **whatever the provided arguments** would result in the ability to ask the
@@ -422,9 +422,9 @@ are self-explanatory for now.
                                 boot platform.
 
       Server selection:
-        -c, --core              Reboot the servers with SDC core components.
+        -c, --core              Reboot the servers with Triton core components.
                                 Note that this will include the headnode.
-        -o, --non-core          Reboot the servers without SDC core
+        -o, --non-core          Reboot the servers without Triton core
                                 components.
         -a, --all               Reboot all the servers.
 

--- a/rfd/0006/README.md
+++ b/rfd/0006/README.md
@@ -13,19 +13,19 @@ state: draft
     Copyright 2015 Joyent Inc.
 -->
 
-# RFD 6 Improving SDC and Manta RAS Infrastructure
+# RFD 6 Improving Triton and Manta RAS Infrastructure
 
 This RFD covers the background of what exists in the operating system
 for reliability and serviceability (RAS) and then goes on from there to
 cover what it might look like to extend this to software components such
-as SDC and Manta. It also looks at hooking into existing RAS artifacts
+as Triton (formerly SmartDataCenter or SDC) and Manta. It also looks at hooking into existing RAS artifacts
 in the system such as the Fault Management Architecture (FMA) in
 illumos.
 
 This RFD serves as an introduction and a high level direction that we
 would like to proceed down. Future RFDs will cover more specific
 component interfaces and explicit APIs. Currently this is focused on
-*operators* of SDC and Manta; however, there's no reason that it could
+*operators* of Triton and Manta; however, there's no reason that it could
 not be extended to users in the future.
 
 
@@ -33,7 +33,7 @@ not be extended to users in the future.
 
 The following is the guiding principle for all of this work:
 
-SDC and Manta operators need to be able to quickly assess the status of
+Triton and Manta operators need to be able to quickly assess the status of
 the entire system and of individual components.  They also need to be
 notified with *actionable* messages whenever problems develop.
 
@@ -46,7 +46,7 @@ like to go through and talk about how this might be used.
 
 ### Actionable Notifications of Developing Problems
 
-As an operator of SDC or Manta who is currently doing something else, I
+As an operator of Triton or Manta who is currently doing something else, I
 need to be notified when problems occur that affect service (e.g., a
 critical service has gone offline) or that compromise the system's
 tolerance to future failures (e.g., a disk fails and a hot spare is
@@ -83,7 +83,7 @@ operator should do about it.  For example:
 
 ### System Status
 
-As an operator of SDC or Manta, I have reason to believe the system is
+As an operator of Triton or Manta, I have reason to believe the system is
 not working correctly.  (This may be because I was just notified or
 because a user has reported a problem.)  I want to walk up to the system
 and quickly assess the status of all components, highlighting those
@@ -168,12 +168,12 @@ article which informs the administrator what has happened, what the
 impact is, what actions have been taken, and what the operator's next
 steps are.
 
-However, while this exists on a per-CN basis, SDC is entirely unaware of
+However, while this exists on a per-CN basis, Triton is entirely unaware of
 it. It has no integration into any facilities to inform operators, be
 collected, logged, etc.
 
 In addition, at the moment there's no way to leverage the ideas of FMA
-inside of SDC. Components can't emit the equivalent of events like
+inside of Triton. Components can't emit the equivalent of events like
 ereports that can be transformed by something into knowledge articles
 which detail information that an operator can use.
 
@@ -331,7 +331,7 @@ Looking back at our use cases, today FMA handles the logic of operations
 A, B, and use cases 2 and 4 within the context of a single system, not
 across the cloud.
 
-Use case 3, on the other hand, listing degraded components, in SDC and
+Use case 3, on the other hand, listing degraded components, in Triton and
 Manta today. While the information can be both polled and pushed, today
 we poll it in the form of things such as sdc-healthcheck and madtom.
 While these may not be the final forms that we want things to take, they
@@ -339,20 +339,20 @@ at least form the starting points.
 
 If we now want to look at what we'd need to do, we'd want to create
 some new interface that helps provide a way for our new software to have
-these events noticed and emitted and have a new SDC component that is in
+these events noticed and emitted and have a new Triton component that is in
 charge of helping deal with these events and potentially perform
 diagnosis. That API would help facilitate the use cases of 1, 2, 4, and
 5 across the cloud and interact with the local fmd as appropriate.
 
 By integrating with the local fmd, we can provide operators a
 centralized view of the state of a given compute node's health. This
-will also allow the new SDC component to integrate with the current
+will also allow the new Triton component to integrate with the current
 notion of cases and retirement that fmd has today.
 
 We may also want to create a new fmd-like daemon which knows how to do
 simpler mappings of events to knowledge articles and tracking that which
 doesn't relate to the current fmd implementation, but leverages the same
-metadata. This would allow an sdc or manta component to emit an event
+metadata. This would allow an Triton or Manta component to emit an event
 that can be noticed, transformed into a knowledge article, and alert an
 operator.
 
@@ -376,7 +376,7 @@ we'd like to make sure are changed about this:
 To that end we have several goals. The biggest is getting tooling to
 make it easy to add non-conflicting events and to have this tooling live
 separate from the event repositories. This allows different event
-repositories, illumos, SDC, Manta, and anything else in the future to
+repositories, illumos, Triton, Manta, and anything else in the future to
 have different sets of events, but share the same tooling.
 
 One of the challenges we have here is that the system has codes for
@@ -417,7 +417,7 @@ center that we could want to talk about or other logical aspects that
 we'd want to consider.
 
 One of the things that operators would like to be able to do, and often
-SDC would like to better leverage, is to paint a picture of the data
+Triton would like to better leverage, is to paint a picture of the data
 center so we know what's in what rack, where. This covers more than just
 compute nodes, but also other things in the data center that operations
 staff have to manage, such as switches. Ideally, we could leverage
@@ -476,7 +476,7 @@ A lot of the things we've discussed have overlaps with existing APIs
 such as amon, cnapi, etc. At this time, this RFD isn't trying to suggest
 where something should or shouldn't be built. It's important that we
 co-exist well with amon's existing uses and make sure that this isn't a
-parallel world, but rather something we can move all of SDC and Manta
+parallel world, but rather something we can move all of Triton and Manta
 to. The specific mechanics of that will be left to future RFDs and
 research.
 

--- a/rfd/0011/README.md
+++ b/rfd/0011/README.md
@@ -3,12 +3,12 @@ authors: Cody Mello <cody.mello@joyent.com>
 state: draft
 ---
 
-# RFD 11 IPv6 and multiple IP addresses support in SDC
+# RFD 11 IPv6 and multiple IP addresses support in Triton
 
 # Introduction
 
 This proposal lays out the work that needs to be done to add support for IPv6 to
-SmartOS and SmartDataCenter (SDC). As the Internet grows and more people come
+SmartOS and Triton (formerly SmartDataCenter or SDC). As the Internet grows and more people come
 online around the globe, ISPs and online businesses are looking towards a future
 where they will need to support IPv6. Major ISPs like AT\&T, Verizon and Comcast
 have already started giving customers IPv6 service and IPv6-enabled modems and
@@ -22,7 +22,7 @@ Parts of the stack have made room for future IPv6 support, but almost everything
 that touches networking will require modifications and testing.
 
 This proposal also suggests a change to the relationship between Network
-Interface Cards (NICs) and IP addresses in SDC. Instead of always having one
+Interface Cards (NICs) and IP addresses in Triton. Instead of always having one
 address per NIC, it should be possible for multiple IP addresses to be placed on
 a single NIC. We call this interface-centric provisioning. The idea is that when
 a machine is being created, it should be possible to request multiple IP
@@ -32,7 +32,7 @@ or overlay.
 
 This document is approximately sorted in the order in which each step will need
 to be implemented. Basic tooling will come first, and then the plumbing through
-SDC. Once that is finished and tested, IPv6 support can be exposed through user
+Triton. Once that is finished and tested, IPv6 support can be exposed through user
 interfaces to end users and operators.
 
 # Support in tooling
@@ -104,11 +104,11 @@ The logic in the brand scripts that prepare the NICs for zones will also need to
 be updated, so that properties like **allowed-ips** and **dhcp-nospoof** will
 get set correctly.
 
-# Support in SDC API's
+# Support in Triton API's
 
 ## Networking API (napi)
 
-The Networking API is responsible for managing data about networks within SDC.
+The Networking API is responsible for managing data about networks within Triton.
 It also takes care of contacting VMAPI and CNAPI for adding, removing and
 updating NICs.
 
@@ -138,7 +138,7 @@ This work was finished in [FWAPI-212] and [FWAPI-225].
 
 # Compute Node Agents
 
-The SDC headnode communicates with each of the compute nodes through agents
+The Triton headnode communicates with each of the compute nodes through agents
 running in their Global Zone. These agents perform a variety of tasks locally,
 ranging from updating the headnode, to making sure that the state on the compute
 node matches what the headnode has stored.
@@ -173,7 +173,7 @@ resources in.
 
 ## Operations Portal (adminui)
 
-The Operations Portal is the web interface for managing SDC and provisioning new
+The Operations Portal is the web interface for managing Triton and provisioning new
 compute nodes and virtual machines. There are several things that will need to
 be updated here:
 
@@ -216,13 +216,13 @@ API will need to be improved to allow returning multiple IPv4 or IPv6 addresses.
 
 # IPv6 on the admin network
 
-Making it possible for SDC to have an IPv6 admin network would be a nice feature
+Making it possible for Triton to have an IPv6 admin network would be a nice feature
 to offer, but it is not essential. Since the admin network is usually a
 non-routable private network, there will probably never be a real need for it to
 support IPv6. As a result, some of these features may be put off for a while.
 They are enumerated here though as a point of reference. Note that as of
 [OS-4802], SmartOS hosts can use IPv6 from the global zone, but this cannot be
-used within SDC.
+used within Triton.
 
 The simplest path to assigning IPv6 addresses to nodes on the admin network
 would be to run [in.ndpd(1M)] alongside Booter, and send out Router
@@ -232,15 +232,15 @@ assigning addresses is needed, then it may be better to use DHCPv6.
 
 ## Binder
 
-Binder is the DNS server used within SDC for locating admin services and compute
-nodes. Currently, it only serves up IPv4 A records. Before SDC can be run on an
+Binder is the DNS server used within Triton for locating admin services and compute
+nodes. Currently, it only serves up IPv4 A records. Before Triton can be run on an
 IPv6 admin network, Binder will need to gain support for serving IPv6 AAAA
 records, so that various programs can continue to look up services on the admin
 network via DNS.
 
 ## Booter
 
-Booter is the DHCP and TFTP server used in SDC for assigning compute nodes IP
+Booter is the DHCP and TFTP server used in Triton for assigning compute nodes IP
 addresses and PXE booting them. In order for IPv6 to be used on the admin
 network, Booter will need to gain support for DHCPv6 so that compute nodes can
 get an IPv6 address and be sent the appropriate options and information to know

--- a/rfd/0021/README.md
+++ b/rfd/0021/README.md
@@ -9,12 +9,12 @@ state: predraft
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
 
-# RFD 21 Metadata Scrubber For SDC
+# RFD 21 Metadata Scrubber For Triton
 
 
 ## Background/Problem
 
-SDC services primarily store metadata in Moray, our key-value store. There are
+Triton (formerly SmartDataCenter or SDC) services primarily store metadata in Moray, our key-value store. There are
 relationships (and therefor dependencies) between the objects we put in there.
 However, we don't actually describe the relationships formally, and this
 sometimes results in unused KV pairs lingering in the store. We want some kind
@@ -63,7 +63,7 @@ following repos.
         sdc-designation
         sdcadm
 
-Clearly it is used to verify objects that are inbound to SDC. We may be able to
+Clearly it is used to verify objects that are inbound to Triton. We may be able to
 extend the `joyent-schemas` code to allow specifiying interdependencies between
 objects in Moray. If not, we will have to roll our own description format.
 

--- a/rfd/0026/README.md
+++ b/rfd/0026/README.md
@@ -7,7 +7,7 @@ state: draft
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-- [RFD 26 Network Shared Storage for SDC](#rfd-26-network-shared-storage-for-sdc)
+- [RFD 26 Network Shared Storage for Triton](#rfd-26-network-shared-storage-for-Triton)
   - [Introduction](#introduction)
   - [Current prototype](#current-prototype)
   - [Use cases](#use-cases)
@@ -143,11 +143,11 @@ state: draft
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-# RFD 26 Network Shared Storage for SDC
+# RFD 26 Network Shared Storage for Triton
 
 ## Introduction
 
-In general, support for network shared storage is antithetical to the SDC
+In general, support for network shared storage is antithetical to the Triton (formerly SmartDataCenter or SDC)
 philosophy. However, for some customers and applications it is a requirement.
 In particular, network shared storage is needed to support Docker volumes in
 configurations where the Triton zones are deployed on different compute nodes.
@@ -255,7 +255,7 @@ works and makes sense to him.
 
 ### Requirements
 
-1. The solution must work for both on-prem SDC users and Triton.
+1. The solution must work for both Triton Cloud and Triton Enterprise users (public cloud and on-prem).
 
 2. A shared volume size must be expandable (i.e. not a fixed quota size at
 creation time).
@@ -282,7 +282,7 @@ The `triton` CLI currently doesn't support the concept of (shared) volumes, so
 new commands and options will need to be added.
 
 The docker CLI already supports shared volumes, but some conventions will need
-to be established to allow Triton users to pass triton-specific input to SDC's
+to be established to allow Triton users to pass triton-specific input to Triton's
 Docker API.
 
 ### Triton
@@ -462,7 +462,7 @@ docker run -d -v wp-uploads:/var/wp-uploads:ro wp-server
 
 ## Shared storage implementation
 
-For reliability reasons, compute nodes never use network block storage and SDC
+For reliability reasons, compute nodes never use network block storage and Triton
 zones are rarely configured with any additional devices. Thus, shared block
 storage is not an option.
 
@@ -1252,7 +1252,7 @@ As for compute packages, volume packages cannot be destroyed.
 Even though shared volumes are implemented as actual zones in a way similar to
 regular instances, they represent an entirely different concept with different
 constraints, requirements and life cycle. As such, they need to be represented
-in SDC as different "Volume" objects.
+in Triton as different "Volume" objects.
 
 The creation, modification and deletion of these "Volume" objects could
 _technically_ be managed by VMAPI, but implementing this API as a separate
@@ -1736,7 +1736,7 @@ sdc-pkgadm volume activate|deactivate $volume-pkg-uuid
 
 ### New `sdc-voladm` command
 
-SDC operators need to be able to perform new operations using a new `sdc-voladm`
+Triton operators need to be able to perform new operations using a new `sdc-voladm`
 command
 
 #### Listing shared volume zones
@@ -1807,7 +1807,7 @@ similarly here.
 
 ### Ownership of NFS shared volumes' storage VMs
 
-In general, for any given object in SDC/Triton, being the owner of an object
+In general, for any given object in Triton, being the owner of an object
 means:
 
 1. being billed for its usage. For instance, VM owners are billed for their CPU
@@ -1872,7 +1872,7 @@ properly bill NAT zones' bandwidth usage to the right user. Using the same
 solution for NFS shared volumes would add another special case to the billing
 process, instead of having it "just work".
 
-Other components of SDC, such as operator tools that gather data about usage per
+Other components of Triton, such as operator tools that gather data about usage per
 user, would need to handle this special ownership representation.
 
 ##### Adding an additional property on VM objects
@@ -1893,17 +1893,17 @@ on VMs' ownership would work transparently. For instance, billing and operators
 tools would not have to be modified to match storage VMs with actual volumes'
 owners.
 
-In general, any tool or internal SDC component would be able to rely on an
+In general, any tool or internal Triton component would be able to rely on an
 internal stable interface when dealing with these internal VMs.
 
 ###### Cons
 
-The implementation of some core SDC components, such as VMAPI's ListVms endpoint
+The implementation of some core Triton components, such as VMAPI's ListVms endpoint
 would need to be modified to filter VMs on the newly added property. The
 `vmapi_vms` moray bucket's schema would need to be changed to add an index on
 this new property and existing objects would need to be backfilled if NAT zones
 were considered as "internal" VMs. In other words, these changes would require
-some additional work that could potentially impact almost every SDC component.
+some additional work that could potentially impact almost every Triton component.
 Depending on the perspective, this is not a problem, but it certainly is very
 much different than the first potential solution mentioned above in that
 respect.

--- a/rfd/0029/README.md
+++ b/rfd/0029/README.md
@@ -3,7 +3,7 @@ authors: Josh Wilsdon <jwilsdon@joyent.com>
 state: draft
 ---
 
-# RFD 29 Nothing in SDC should rely on ur outside bootstrapping and emergencies
+# RFD 29 Nothing in Triton should rely on ur outside bootstrapping and emergencies
 
 ## Introduction
 
@@ -41,7 +41,7 @@ difficult to track since for the most part these commands are not logging what
 they're doing.
 
 In order to fix this, we should make sure that nothing except bootstrapping
-(joysetup + initial agents install) in SDC depends on Ur. This will force tools
+(joysetup + initial agents install) in Triton depends on Ur. This will force tools
 to use a more specific API and likely to add things to CNAPI/cn-agent that
 abstract away the details of the CN commands themselves.
 


### PR DESCRIPTION
This PR renames all references to SDC as a product to Triton in RFD's. This is important to prevent user and customer confusion following the renaming of SmartDataCenter to Triton in 2015.

Not included:

- One RFD that is in a published state
- Mentions of the SDC product in RFDs that didn't mention it in their title
- References to interfaces, APIs, or tools that include 'sdc' as part of their name; we are making no effort to rename existing interfaces or tools except in the case that e're significantly refactoring/replacing them for other reasons