### PR TITLE
Stubbing out three RFDs for Mariposa-related components

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ formal writing that it has come to represent.)
 | draft    | [RFD 76 Improving Manta Networking Setup](./rfd/0076/README.md) |
 | predraft | [RFD 77 Hardware-backed per-zone crypto tokens](./rfd/0077/README.md) |
 | draft | [RFD 78 Making Moray's findobjects requests robust with regards to unindexed fields](./rfd/0078/README.md) |
+| (WIP) | [RFD 79 Projects, Projects-Services, and Projects-Meta implementation](./rfd/0079/README.md) |
+| (WIP) | [RFD 80 Projects-Convergence implementation](./rfd/0080/README.md) |
+| (WIP) | [RFD 81 Services-Health implementation](./rfd/0081/README.md) |
 
 ## Contents of an RFD
 

--- a/rfd/0079/README.md
+++ b/rfd/0079/README.md
@@ -1,0 +1,7 @@
+---
+authors: Casey Bisson <casey.bisson@joyent.com>, Jason Pincin <jason.pincin@joyent.com>
+state: predraft
+---
+
+# RFD 79 Projects, projectsServices, and projectsMeta implementation
+

--- a/rfd/0080/README.md
+++ b/rfd/0080/README.md
@@ -1,0 +1,6 @@
+---
+authors: Casey Bisson <casey.bisson@joyent.com>, Jason Pincin <jason.pincin@joyent.com>
+state: predraft
+---
+
+# RFD 80 projectsConvergence implementation

--- a/rfd/0081/README.md
+++ b/rfd/0081/README.md
@@ -1,0 +1,6 @@
+---
+authors: Casey Bisson <casey.bisson@joyent.com>, Jason Pincin <jason.pincin@joyent.com>
+state: predraft
+---
+
+# RFD 81 servicesHealth implementation


### PR DESCRIPTION
The three RFDs represent what we believe to be a set of services to implement a significant portion of Mariposa as described in [RFD36](https://github.com/joyent/rfd/blob/master/rfd/0036/README.md). While RFD36 describes Mariposa from the user's perspective, these attempt to describe the necessary services and their implementation.

These services include (names provided for convenience here, I expect we'll change them after discussion):

- Projects, which may also include a services and meta details (as well as questions about whether those should all be endpoints in the same service or separate services)
- Convergence, the component responsible for comparing the goal state of the project to the actual state of the instances, devising a plan to resolve any differences, and executing that plan
- Health, the component that executes user-defined health checks on the instances of a project/service

Work on these RFDs has progressed to the point where it seems reasonable to secure RFD numbers and rewrite them for discussion here.