### PR TITLE
RFD86 ContainerPilot 3 draft

### DIFF
--- a/rfd/0086/README.md
+++ b/rfd/0086/README.md
@@ -2,6 +2,21 @@
 authors: Tim Gross <tim.gross@joyent.com>
 state: predraft
 ----
+<!--
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
 
 
 # RFD 86 ContainerPilot 3
+
+ContainerPilot is an application-centric micro-orchestrator that automates the process of service discovery, configuration, and lifecycle management inside a container. ContainerPilot v1 ("ContainerBuddy") explored these ideas, ContainerPilot v2 was a production-ready expression of those ideas. ContainerPilot v3 will take the lessons learned from real-world production usage of ContainerPilot and refine its behavior. Additionally, ContainerPilot v3 will have features intended to interoperate with new application management features of Triton described in [RFD36 "Mariposa"](https://github.com/joyent/rfd/blob/master/rfd/0036/README.md).
+
+This RFD is broken into multiple sections:
+
+- [First-class support for multi-process containers](multiprocess.md)
+- [Mariposa integration](mariposa.md)
+- [Configuration improvements](config.md)
+- [Backwards compatibility and support](compat.md)
+- [Consolidate discovery on Consul](consul.md)

--- a/rfd/0086/compat.md
+++ b/rfd/0086/compat.md
@@ -44,4 +44,4 @@ ContainerPilot 2.x will be tagged in GitHub but marked as deprecated. The `maste
 
 ##### Joyent Support
 
-There are several organizations using ContainerPilot 2.x in production. We will support ContainerPilot 2.x for _N_?? (TODO) with bug fixes released as patch versions but without additional features being added.
+There are several organizations using ContainerPilot 2.x in production. We will support ContainerPilot 2.x for 3 months after the 3.0.0 final release with bug fixes released as patch versions but without additional features being added.

--- a/rfd/0086/compat.md
+++ b/rfd/0086/compat.md
@@ -30,7 +30,7 @@ The changes in this RFD leave the general interface of forking behavior hooks un
 - `preStart`, `preStop`, and `postStop` hooks will be folded into the new [dependency management](multiprocess.md#dependency-management).
 - `coprocess` and `task` hooks will be folded into the new multi-process configuration with [no-advertise](multiprocess.md#no-advertise).
 
-In the case of `sensors` the existing interface is to read the stdout of the forked process and parse it as a value, but this has proven to be brittle and reduces debuggability. Instead `sensors` will use the proposed [`PutMetric`](mariposa.md#control-plane-endpoint) API to record metrics.
+In the case of `sensors` the existing interface is to read the stdout of the forked process and parse it as a value, but this has proven to be brittle and reduces debuggability. Instead `sensors` will use the proposed [`PutMetric`](mariposa.md#putmetric-post-v3metric) API to record metrics.
 
 ##### Internal ContainerPilot APIs
 

--- a/rfd/0086/compat.md
+++ b/rfd/0086/compat.md
@@ -1,7 +1,47 @@
 ## Backwards compatibility and support
 
-The changes in this RFD are not backwards compatible with ContainerPilot 2.x configuration. For end users using Consul as their discovery backend, each container image can be safely updated independently; there is no communication between ContainerPilot instances except through the Consul API.
+There are several interfaces to consider for ContainerPilot backwards compatibility:
 
-There are several organizations using ContainerPilot 2.x in production. We will support ContainerPilot 2.x for _N_?? with bug fixes released as patch versions but without additional features being added.
+1. [The interface with the discovery service (Consul or etcd).](#interface-with-the-discovery-service)
+2. [The interface exposed to Prometheus-compatible clients.](#interface-with-prometheus)
+3. [The ContainerPilot configuration file and arguments.](#containerpilot-configuration)
+4. [The interface with behavior hooks.](#behavior-hooks)
+5. [The internal ContainerPilot APIs with its golang packages.](#internal-containerpilot-apis)
+6. [The interface with the ContainerPilot development community.](#containerpilot-development-community)
+7. [The interface with Joyent Support.](#joyent-support)
 
-ContainerPilot 2.x will be tagged in GitHub but marked as deprecated. The `master` branch on GitHub will be for 3.x development but will be noted as "unstable" until ready to ship the first release.
+
+##### Interface with the discovery service
+
+The proposal to [consolidate discovery on Consul](consul.md) means that any users of the etcd backend will need to move to Consul in order to upgrade to ContainerPilot 3. For end users using Consul as their discovery backend, each container image can be safely updated independently; there is no communication between ContainerPilot instances except through the Consul API. The interface with Consul itself will remain unchanged.
+
+##### Interface with Prometheus
+
+This interface will remain unchanged except as we upgrade any Prometheus client library bindings over time.
+
+##### ContainerPilot configuration
+
+The changes in this RFD are not backwards compatible with ContainerPilot 2.x configuration and each container image using ContainerPilot will need to be newly configured. Upgrading can be done independently for each application image, as there is no communication between ContainerPilot instances except through the Consul API. This should allow organizations to do an upgrade over time.
+
+##### Behavior hooks
+
+The changes in this RFD leave the general interface of forking behavior hooks unchanged; the executables are forked and the exit code of the hook determines success. Many of the separate behavior hooks will be merged together in ContainerPilot 3:
+
+- `preStart`, `preStop`, and `postStop` hooks will be folded into the new [dependency management](multiprocess.md#dependency-management).
+- `coprocess` and `task` hooks will be folded into the new multi-process configuration with [no-advertise](multiprocess.md#no-advertise).
+
+In the case of `sensors` the existing interface is to read the stdout of the forked process and parse it as a value, but this has proven to be brittle and reduces debuggability. Instead `sensors` will use the proposed [`PutMetric`](mariposa.md#control-plane-endpoint) API to record metrics.
+
+##### Internal ContainerPilot APIs
+
+Although the ContainerPilot code base is broken into multiple packages, the interfaces have not been designed for independent consumption. The stability of these APIs has not been guaranteed and we should document this as part of contributor guidelines.
+
+
+##### ContainerPilot development community
+
+ContainerPilot 2.x will be tagged in GitHub but marked as deprecated. The `master` branch on GitHub will be for 3.x development but will be noted as "unstable" until ready to ship the first release. We will also expand the contributor guidelines and generally improve the "first contribution" story over the period of this work.
+
+
+##### Joyent Support
+
+There are several organizations using ContainerPilot 2.x in production. We will support ContainerPilot 2.x for _N_?? (TODO) with bug fixes released as patch versions but without additional features being added.

--- a/rfd/0086/compat.md
+++ b/rfd/0086/compat.md
@@ -1,0 +1,7 @@
+## Backwards compatibility and support
+
+The changes in this RFD are not backwards compatible with ContainerPilot 2.x configuration. For end users using Consul as their discovery backend, each container image can be safely updated independently; there is no communication between ContainerPilot instances except through the Consul API.
+
+There are several organizations using ContainerPilot 2.x in production. We will support ContainerPilot 2.x for _N_?? with bug fixes released as patch versions but without additional features being added.
+
+ContainerPilot 2.x will be tagged in GitHub but marked as deprecated. The `master` branch on GitHub will be for 3.x development but will be noted as "unstable" until ready to ship the first release.

--- a/rfd/0086/config.md
+++ b/rfd/0086/config.md
@@ -1,0 +1,180 @@
+## Configuration syntax improvements
+
+JSON as a configuration language leaves much to be desired. It has no comments, is unforgiving in editing (we've specifically written code in ContainerPilot to point out extraneous trailing commas in the config!). Any configuration language change should also support those users we know who are generating ContainerPilot configurations automatically.
+
+We will abandon JSON in favor of the more human-friendly YAML configuration language. It has a particular advantage for those users who are generating configuration because of the ubiquity of YAML-generating libraries (this is its major advantage over Hashicorp HCL). During ContainerPilot configuration loading, we can check for files in `/etc/containerpilot.d/` (a configurable location via the `-config` flag) and merge them together.
+
+The merging process is as follows:
+
+- Lexigraphically sort all the config files.
+- Multiple `service`, `health`, `sensor` blocks are unioned.
+- Keys with the same name replace those that occurred previously.
+
+For example consider the two YAML files below.
+
+1.yml
+```
+consul:
+  host: localhost:8500
+
+services:
+  nginx:
+    port: 80
+
+  app-A:
+    port: 8000
+
+health:
+  nginx:
+    check-A:
+      command: curl -s --fail localhost/health
+
+```
+
+2.yml
+```
+consul:
+  host: consul.svc.triton.zone
+
+services:
+  app-A:
+    port: 9000
+
+  app-B:
+    port: 8000
+
+health:
+  nginx:
+    check-B:
+      command: curl -s --fail localhost/otherhealth
+
+```
+
+These will be merged as follows:
+
+```
+consul:
+  host: consul.svc.triton.zone
+
+services:
+  nginx:
+    port: 80
+
+  app-A:
+    port: 9000
+
+  app-B:
+    port: 8000
+
+health:
+  nginx:
+    check-A:
+      command: curl -s --fail localhost/health
+    check-B:
+      command: curl -s --fail localhost/otherhealth
+
+```
+
+
+The full example configuration for ContainerPilot found in the existing docs would look like the following:
+
+
+```
+consul:
+  host: localhost:8500
+
+logging:
+  level: INFO
+  format: default
+  output: stdout
+
+service:
+  app:
+    port: 80
+    heartbeat: 5
+    tll: 10
+    tags:
+    - app
+    - prod
+    interfaces:
+    - eth0
+    - eth1[1]
+    - 192.168.0.0/16
+    - 2001:db8::/64
+    - eth2:inet
+    - eth2:inet6
+    - inet
+    - inet6
+    - static:192.168.1.100"
+
+    stopTimeout: 5
+    preStop: /usr/local/bin/preStop-script.sh
+    postStop: /usr/local/bin/postStop-script.sh
+
+    depends:
+      setup:
+        wait: success
+      nginx:
+        onChange: /usr/local/bin/reload-nginx.sh
+        poll: 30
+        timeout: "30s"
+      consul-agent:
+        wait: healthy
+      app:
+        onChange: /usr/local/bin/reload-app.sh
+        poll: 10
+        timeout: "10s"
+
+  setup:
+    command: /usr/local/bin/preStart-script.sh {{.ENV_VAR_NAME}}
+    advertise: false
+    restart: never
+
+  consul-agent:
+    port: 8500
+    command: consul -agent -join consul
+    advertise: false
+    restart: always
+
+  consul-template:
+    command: >
+      consul-template -consul consul
+          -template /tmp/template.ctmpl:/tmp/result
+    advertise: false
+    restart: always
+
+  task1:
+    command: /usr/local/bin/tash.sh arg1
+    frequency: 1500ms
+    timeout: 100ms
+    advertise: false
+
+
+health:
+  nginx:
+    check-A:
+      command: >
+        /usr/bin/curl --fail -s -o /dev/null http://localhost/app
+      poll: 5
+      timeout: "5s"
+
+telemetry:
+  port: 9090
+  interfaces:
+  - eth0
+
+sensor:
+  name: metric_id
+  help: help text
+  type: counter
+  poll: 5
+  check: /usr/local/bin/sensor.sh
+
+```
+
+_Related GitHub issues:_
+- [support containerpilot.d config directory](https://github.com/joyent/containerpilot/issues/236)
+- [onEvent hook](https://github.com/joyent/containerpilot/issues/227)
+- [environment section for config](https://github.com/joyent/containerpilot/issues/232)
+- [more env vars](https://github.com/joyent/containerpilot/issues/229)
+- [configurable service names](https://github.com/joyent/containerpilot/issues/193)

--- a/rfd/0086/consul.md
+++ b/rfd/0086/consul.md
@@ -1,0 +1,23 @@
+## Consolidate discovery on Consul
+
+Consul provides a number of higher-level capabilities than a simple KV store like etcd or ZK. Providing the ability to use these capabilities means either going with a least-common-denominator approach or having complex provider-specific configuration options for tagging interfaces, providing secure connection to the backend, and faster deregistration on shutdown, among others.
+
+All the Autopilot Pattern example applications are using Consul (with the sole exception of the etcd blueprint). All known users of ContainerPilot are using Consul. Dropping support for anything other than Consul would reduce the scope of testing and development.
+
+The primary argument against dropping non-Consul support (and one we should not dismiss easily) is that Kubernetes and related projects are using etcd as the service discovery layer. In our discussions with some end users, we haven't found that there's any resistance to the idea that the scheduler's own consensus & membership store doesn't need to be the same store used by applications. And even perhaps _should not_ be the same store, given that in most organizations the team responsible for application development will not be the same team responsible for running the deployment platform.
+
+Another option that's been discussed is to embed the Consul agent inside ContainerPilot, so that ContainerPilot acts as a Consul agent on its own. This would make it more similar the [Habitat supervisor](https://habitat.sh) and reduce the complexity for end users who need to configure a coprocess for Consul agent currently. We've rejected this option to avoid risks of sharing memory with Consul, to allow us to drop-in new versions of Consul without code changes, and to avoid the inevitable scope creep when someone suggests why the agent couldn't also support `consul-template` behavior.
+
+**Related GitHub issues:**
+
+- [Drop support for non-Consul discovery backends](https://github.com/joyent/containerpilot/issues/251)
+- [Consul agent discovery backend](https://github.com/joyent/containerpilot/issues/246)
+- [Support for Zookeeper (stalled)](https://github.com/joyent/containerpilot/issues/142)
+
+Example of Consul-specific feature support:
+
+- [Node deregistration from Consul](https://github.com/joyent/containerpilot/issues/218)
+- [Support Consul EnableTagOverride](https://github.com/joyent/containerpilot/issues/243)
+- [Support Consul TaggedAddresses](https://github.com/joyent/containerpilot/issues/226)
+- [Consul client certs](https://github.com/joyent/containerpilot/issues/169)
+- [Consul availability timeout](https://github.com/joyent/containerpilot/issues/164)

--- a/rfd/0086/mariposa.md
+++ b/rfd/0086/mariposa.md
@@ -8,7 +8,7 @@ The proposal is in two parts. A read-only endpoint exposing the state of all ser
 
 ### Telemetry endpoint
 
-**`GetStatus GET /status`**
+##### `GetStatus GET /status`
 
 This API will expose the state of all services associated with this ContainerPilot instance.
 
@@ -38,7 +38,7 @@ Content-Length: 328
 
 ### Control plane endpoint
 
-**`PutEnviron POST /v3/environ`**
+##### `PutEnviron POST /v3/environ`
 
 This API allows a hook to update the environment variables that ContainerPilot provides to lifecycle hooks. The body of the POST must be in JSON format. The keys will be used as the environment variable to set, and the values will be the values to set for those environment variables. The environment variables take effect for all future processes spawned and override any existing environment variables. Unsetting an variable is supporting by passing an empty string or `null` as the JSON value for that key. This API returns HTTP400 if the the key is not a valid environment variable name, otherwise HTTP200 with no body.
 
@@ -51,7 +51,7 @@ curl -XPOST \
     http:/v3/environ
 ```
 
-**`PutMetric POST /v3/metric`**
+##### `PutMetric POST /v3/metric`
 
 This API allows a sensor hook to update Prometheus metrics. (This allows sensor hooks to do so without having to suppress their own logging, which is required under 2.x.) The body of the POST must be in JSON format. The keys will be used as the metric names to update, and the values will be the values to set/add for those metrics. The API will return HTTP400 if the metric is not one that ContainerPilot is configuring, otherwise HTTP200 with no body.
 
@@ -64,7 +64,7 @@ curl -XPOST \
     http:/v3/environ
 ```
 
-**`Reload POST /v3/reload`**
+##### `Reload POST /v3/reload`
 
 This API allows a hook to force ContainerPilot to reload its configuration from file. This replaces the SIGHUP handler from 2.x and behaves identically: all pollables are stopped, the configuration file is reloaded, and the pollables are restarted without interfering with the services. This endpoint returns a HTTP200 with no body.
 
@@ -76,7 +76,7 @@ curl -XPOST \
     http:/v3/reload
 ```
 
-**`MaintenanceMode POST /v3/maintenance`**
+##### `MaintenanceMode POST /v3/maintenance`
 
 This API allows a hook to force ContainerPilot to go into maintenance mode. This replaces the SIGUSR1 handler from 2.x and behaves identically: all health checks are stopped and the discovery backend is sent a message to deregister the services. This endpoint returns a HTTP200 with no body.
 

--- a/rfd/0086/mariposa.md
+++ b/rfd/0086/mariposa.md
@@ -41,7 +41,7 @@ Content-Length: 328
 
 ##### `PutEnv POST /v3/env`
 
-This API allows a hook to update the environment variables that ContainerPilot provides to lifecycle hooks. The body of the POST must be in JSON format. The keys will be used as the environment variable to set, and the values will be the values to set for those environment variables. The environment variables take effect for all future processes spawned and override any existing environment variables. Unsetting an variable is supporting by passing an empty string or `null` as the JSON value for that key. This API returns HTTP400 if the the key is not a valid environment variable name, otherwise HTTP200 with no body.
+This API allows a hook to update the environment variables that ContainerPilot provides to lifecycle hooks. The body of the POST must be in JSON format. The keys will be used as the environment variable to set, and the values will be the values to set for those environment variables. The environment variables take effect for all future processes spawned and override any existing environment variables. Unsetting an variable is supporting by passing an empty string or `null` as the JSON value for that key. This API returns HTTP400 if the key is not a valid environment variable name, otherwise HTTP200 with no body.
 
 *Example Request*
 

--- a/rfd/0086/mariposa.md
+++ b/rfd/0086/mariposa.md
@@ -10,7 +10,7 @@ The proposal is in two parts. A read-only endpoint exposing the state of all ser
 
 ##### `GetStatus GET /status`
 
-This API will expose the state of all services associated with this ContainerPilot instance.
+This API will expose the state of all services associated with this ContainerPilot instance, including their dependencies.
 
 *Example Response*
 
@@ -25,6 +25,7 @@ Content-Length: 328
       "address": "192.168.1.100",
       "port": 80,
       "status": "healthy"
+      "depends_on": ["backend1", "backend2"]
     },
     {
       "name": "consul_agent",
@@ -38,7 +39,7 @@ Content-Length: 328
 
 ### Control plane endpoint
 
-##### `PutEnviron POST /v3/environ`
+##### `PutEnv POST /v3/env`
 
 This API allows a hook to update the environment variables that ContainerPilot provides to lifecycle hooks. The body of the POST must be in JSON format. The keys will be used as the environment variable to set, and the values will be the values to set for those environment variables. The environment variables take effect for all future processes spawned and override any existing environment variables. Unsetting an variable is supporting by passing an empty string or `null` as the JSON value for that key. This API returns HTTP400 if the the key is not a valid environment variable name, otherwise HTTP200 with no body.
 
@@ -48,7 +49,7 @@ This API allows a hook to update the environment variables that ContainerPilot p
 curl -XPOST \
     -d '{"ENV1": "value1", "ENV2": "value2", "ENV_TO_CLEAR": ""}' \
     --unix-socket /var/containerpilot.sock \
-    http:/v3/environ
+    http:/v3/env
 ```
 
 ##### `PutMetric POST /v3/metric`

--- a/rfd/0086/mariposa.md
+++ b/rfd/0086/mariposa.md
@@ -79,7 +79,7 @@ curl -XPOST \
 
 ##### `MaintenanceMode POST /v3/maintenance`
 
-This API allows a hook to force ContainerPilot to go into maintenance mode. This replaces the SIGUSR1 handler from 2.x and behaves identically: all health checks are stopped and the discovery backend is sent a message to deregister the services. This endpoint returns a HTTP200 with no body.
+This API allows a hook to toggle ContainerPilot's maintenance mode. This replaces the SIGUSR1 handler from 2.x and behaves identically: all health checks are stopped and the discovery backend is sent a message to deregister the services. Making the same request when in maintenance mode causes ContainerPilot to exit maintenance mode. This endpoint returns a HTTP200 with no body.
 
 *Example Request*
 

--- a/rfd/0086/mariposa.md
+++ b/rfd/0086/mariposa.md
@@ -1,0 +1,73 @@
+## Mariposa integration
+
+There are a number of cases where we've wanted for lifecycle hooks to be able to communicate information back to ContainerPilot, or to be otherwise able to alter the ContainerPilot environment for purposes of future handler events or the main application itself. Additionally, it's likely that we at Joyent will want the [RFD36](https://github.com/joyent/rfd/blob/master/rfd/0036/README.md) scheduler for Triton to be able to have an interface to communicate with containers and ContainerPilot itself, for which we can provide an example in ContainerPilot.
+
+This control plane would be useful for event hooks as well. Telemetry sensor outputs will be consumed via a robust API instead of the existing brittle text scraping. Event hooks will also be able to set environment variables for other services and event hooks.
+
+This proposal is to create an HTTP server for ContainerPilot that exposes a simple HTTP REST protocol. *TODO: we need to have a discussion about security here: TLS, authn/authz*
+
+**`GetStatus GET /v3/status`**
+
+This API will expose the state of all services associated with this ContainerPilot instance.
+
+*Example Response*
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 328
+{
+  "services": [
+    {
+      "name": "nginx",
+      "address": "192.168.1.100",
+      "port": 80,
+      "status": "healthy"
+    },
+    {
+      "name": "consul_agent",
+      "address": "localhost",
+      "port": 8500,
+      "status": "nonadvertised"
+    }
+  ]
+}
+```
+
+**`PutEnviron POST /v3/environ`**
+
+This API allows a hook to update the environment variables that ContainerPilot provides to lifecycle hooks. The body of the POST must be in JSON format. The keys will be used as the environment variable to set, and the values will be the values to set for those environment variables. The environment variables take effect for all future processes spawned. This API returns HTTP400 if the the key is not a valid environment variable name, otherwise HTTP200 with no body.
+
+*Example Request*
+
+```
+curl -XPOST \
+    -d '{"ENV1": "value1", "ENV2": "value2"}' \
+    http:/v3/environ
+```
+
+**`PutMetric POST /v3/metric`**
+
+This API allows a sensor hook to update Prometheus metrics. (This allows sensor hooks to do so without having to suppress their own logging, which is required under 2.x.) The body of the POST must be in JSON format. The keys will be used as the metric names to update, and the values will be the values to set/add for those metrics. The API will return HTTP400 if the metric is not one that ContainerPilot is configuring, otherwise HTTP200 with no body.
+
+*Example Request*
+
+```
+curl -XPOST \
+    -d '{"my_counter_metric": 2, "my_gauge_metric": 42.42}' \
+    http:/v3/environ
+```
+
+**`Reload POST /v3/reload`**
+
+This API allows a hook to force ContainerPilot to reload its configuration from file. This replaces the SIGHUP handler from 2.x and behaves identically: all pollables are stopped, the configuration file is reloaded, and the pollables are restarted without interfering with the services. This endpoint returns a HTTP200 with no body.
+
+**`MaintenanceMode POST /v3/maintenance`**
+
+This API allows a hook to force ContainerPilot to go into maintenance mode. This replaces the SIGUSR1 handler from 2.x and behaves identically: all health checks are stopped and the discovery backend is sent a message to deregister the services. This endpoint returns a HTTP200 with no body.
+
+Related GitHub issues:
+- [Expose ContainerPilot state thru telemetry](https://github.com/joyent/containerpilot/issues/154)
+- [HTTP control plane](https://github.com/joyent/containerpilot/issues/244)
+- [Ability to pass SIGUSR1 and SIGHUP to main app](https://github.com/joyent/containerpilot/issues/195)
+- [SIGINT termination and coprocess suspension](https://github.com/joyent/containerpilot/pull/186)

--- a/rfd/0086/multiprocess.md
+++ b/rfd/0086/multiprocess.md
@@ -1,0 +1,177 @@
+## First-class support for multi-process containers
+
+ContainerPilot currently "shims" a single application -- it blocks until this main application exits and spins up concurrent threads to perform the various lifecycle hooks. ContainerPilot was originally dedicated to the control of a single persistent application, and this differentiated it from a typical init system.
+
+In v2 we expanded the polling behaviors of `health` checks and `onChange` handlers to include periodic `tasks` [#27](https://github.com/joyent/containerpilot/issues/27). Correctly supporting Consul or etcd on Triton (or any CaaS/PaaS) means requiring an agent running inside the container, and so we also expanded to include persistent `coprocesses`. Users have reported problems with ContainerPilot (via GitHub issues) that stem from two areas of confusion around these features:
+
+- The configuration of the main process is via the command line whereas the configuration of the various supporting processes is via the config file.
+- The timing of when each process starts is specific to which configuration block it's in (main vs `task` vs `coprocess`) rather than its dependencies.
+
+#### Multiple services
+
+In v3 we'll eliminate the concept of a "main" application and embrace the notion that ContainerPilot is an init system for running inside containers. Each process will have its own health check(s), dependencies, frequency of run or restarting ("run forever", "run once", "run every N seconds"), and lifecycle hooks for startup and shutdown.
+
+For each application managed, the command will be included in the ContainerPilot `services` block. This change eliminates the `task` and `coprocess` config sections. For running the applications we can largely reuse the existing process running code, which includes `SIGCHLD` handlers for process reaping. Below is an example configuration, assuming we use YAML rather than JSON (see [config updates](config.md) for more details).
+
+```yml
+services:
+  nginx:
+    command: nginx -g daemon off;
+    port: 80
+    heartbeat: 5
+    ttl: 10
+    interfaces:
+      - eth0
+      - eth1
+    depends:
+      - consul_agent
+
+  consul_agent:
+    command: consul -agent
+    port: 8500
+    interfaces:
+      - localhost
+    advertise: false
+
+health:
+    nginx:
+      check: curl --fail http://localhost/app
+      poll: 5
+      timeout: "5s"
+
+```
+
+_Related GitHub issues:_
+- [Support containerpilot.d config directory](https://github.com/joyent/containerpilot/issues/236)
+- [Allow multiple health checks per service](https://github.com/joyent/containerpilot/issues/245)
+- [Allow multiple commands for preStart](https://github.com/joyent/containerpilot/issues/253)
+- [Prevent polling/coprocesses from being started multiple times](https://github.com/joyent/containerpilot/pull/198)
+- [Coprocess hooks](https://github.com/joyent/containerpilot/issues/175)
+- [preStart a background process](https://github.com/joyent/containerpilot/issues/157)
+- [registering containers as separate nodes on Consul](https://github.com/joyent/containerpilot/issues/162)
+
+
+#### Multiple health checks
+
+ContainerPilot 3 will support the ability for a service to have multiple health checks. All health checks for a service must be in a passing state before a service can be marked as healthy. The service definition will be separated from the health check definition in order to support proposed [configuration improvements](config.md).
+
+We'll make the following changes:
+
+- ContainerPilot will maintain state for all services, which can be either `healthy` or `unhealthy`, and all health checks, which can be either `passing` or `failing`.
+- All health checks must be marked `passing` before ContainerPilot will mark the service a `healthy`.
+- A service in a `healthy` state will send heartbeats (a `Pass` message) to the discovery backend every `heartbeat` seconds with a TTL of `ttl`.
+- A health check will poll every `poll` seconds, with a timeout of `timeout`. If any health check fails (returns a non-zero exit code or times out), the associated service is marked `unhealthy` and a `Fail` message is sent to the discovery service.
+- Once any health check fails, _all_ health checks need to pass before the service will be marked healthy again. This is required to avoid service flapping.
+
+**Important note:** end users should not provide a health check with a long polling time to perform some supporting task like backends. This will cause "slow startup" as their service will not be marked healthy until the first polling window expires. Instead they should create another service for this task.
+
+```
+consul:
+  host: consul.svc.triton.zone
+
+services:
+  nginx:
+    port: 80
+    heartbeat: 5
+    ttl: 10
+
+health:
+  nginx:
+    check-A:
+      command: curl -s --fail localhost/health
+    check-B:
+      command: curl -s --fail localhost/otherhealth
+
+```
+
+
+_Related GitHub issues:_
+- [Support containerpilot.d config directory](https://github.com/joyent/containerpilot/issues/236)
+- [Allow multiple health checks per service](https://github.com/joyent/containerpilot/issues/245)
+
+
+#### "No advertise"
+
+Some applications are intended only for internal consumption by other applications in the container not should not be advertised to the discovery layer (ex. Consul agent). These applications can mark themselves as "no advertise." ContainerPilot will track the state of non-advertising applications but not register them with service discovery, so it can fire `onChange` handlers for other services that depend on it. In the example above, the Consul Agent will not be advertised but Nginx can still have it marked as a dependency.
+
+_Related GitHub issues:_
+- [Coprocess hooks](https://github.com/joyent/containerpilot/issues/175)
+- [registering services w/o ports](https://github.com/joyent/containerpilot/issues/117)
+
+
+#### Dependency management
+
+Applications running under ContainerPilot have external dependencies, and the current design does not adequately account for the variety of dependencies we've encountered from users.
+
+1. Applications may depend on an external service. For example an Nginx upstream or database.
+2. Applications may depend on a local service (inside the container). For example it can't know the health of external dependencies without having the local Consul Agent.
+3. Applications may depend on environment variables to be set.
+4. Applications may depend on generated files that are not in the container image. For example Nginx with `consul-template` expects the rendered configuration to replace the one from the image.
+5. Application dependencies may be hard: the application process can't start without the dependency without exiting.
+6. Application dependencies may be quasi-hard: the application process can start without the dependency but the application can't operate correctly until the dependency becomes available (it might retry or poll for the dependency).
+7. Application dependencies may be soft: the application process can start without the dependency and operates in a degraded state but is safe to mark as healthy.
+
+ContainerPilot currently supports (1) well by original design, supports (2) via coprocess, and supports (3) and (4) if the user has added the appropriate lifecycle hooks. The "hardness" of a dependency (5)(6)(7) is intended to be managed by the end user's `health` and `onChange` handlers. What makes an application "healthy" is left as a user concern and ContainerPilot will only report backends that are marked healthy. This has been a frequent source of feature requests that amount to a `postStart` hook.
+
+ContainerPilot hasn't eliminated the complexity of dependency management -- that doesn't work without proscribing a narrow set of behaviors like 12Factor, which rules out stateful applications -- but we have tamed that complexity by moving it into the container so that it's owned by the people who know the most about what the application needs.
+
+That being said, a more expressive configuration of event handlers may more gracefully handle all the above situations and reduce the end-user confusion. Rather than surfacing just changes to dependency membership lists, we'll expose changes to the overall state as ContainerPilot sees it.
+
+ContainerPilot will provide the following events:
+
+- `onSuccess`: when a service exits with exit code 0.
+- `onFail`: when a service exits with a non-zero exit code.
+- `onHealthy`: when ContainerPilot receives notice that the dependency has been marked healthy. This is only triggered when there were previously no healthy instances (typically when the application first starts but also if all instances have previously failed).
+- `onChange`: when ContainerPilot receives notice of a change to the membership of a service.
+- `onUnhealthy`: when ContainerPilot receives notices that the dependency has been marked unhealthy (no instances available of a previously healthy service).
+
+Services can have additional options for their dependencies:
+
+- `wait`: do not start the service until the desired state has been reached. Fire any other event handlers associated with the state before starting the application.
+- `timeout`: if the dependency is unhealthy for this period of time, mark this service as failed as well.
+
+In the example below, we have a Node.js service `app`. The Node app needs configuration from the environment before it can start, so it must wait until a one-time service named `setup` has completed successfully. It will wait until `consul_agent` and `database` have been marked healthy, and will automatically reconfigure itself on changes to the `database` and `redis`.
+
+
+```yml
+services:
+  app:
+    depends:
+
+      # `app` will not start if `setup` fails
+      setup:
+        wait: onSuccess
+
+      # ContainerPilot will give the agent 60 sec to become healthy,
+      # otherwise mark `app` as failed
+      consul_agent:
+        wait: onHealthy
+        timeout: "60s"
+
+      # `app` needs this DB and also needs to configure itself when the DB
+      # is healthy. It reloads its config if the DB changes.
+      database:
+        wait: onHealthy
+        timeout: "60s"
+        onHealthy: configure-db-connnection.sh
+        onChange: reload-db-connections.sh
+
+      # `app` gracefully handles missing redis so we just update the config
+      # whenever the list of members changes
+      redis:
+        onChange: reload-configuration.sh
+```
+
+Note that to avoid stalled containers, ContainerPilot will need to automatically detect unresolvable states. In the example above, if `setup` fails ContainerPilot will never start `app`, so it should mark the `app` service state as failed as well. If ContainerPilot reaches a state where no services can continue, it will exit.
+
+This change eliminates the current `preStart` configuration. Instead a user will have a one-time service that all other services depend on (like `setup` above). With multi-application support we can create a chain of dependencies.
+
+_Related GitHub issues:_
+- [Startup dependency sequencing](https://github.com/joyent/containerpilot/issues/273)
+- [Proposal for onEvent hook](https://github.com/joyent/containerpilot/issues/227)
+- [Allow preStart to set environment of application](https://github.com/joyent/containerpilot/issues/205)
+- [Questions about backend service status](https://github.com/joyent/containerpilot/issues/160)
+- [Handling apps that can't reload config](https://github.com/joyent/containerpilot/issues/126)
+- [Yet another proposal for "post start"](https://github.com/joyent/containerpilot/issues/196)
+- [Yet another proposal for "post start"](https://github.com/joyent/containerpilot/issues/173)
+- [Yet another proposal for "post start"](https://github.com/joyent/containerpilot/issues/204)


### PR DESCRIPTION
Draft RFD for ContainerPilot 3 ahead of the February engineering summit where we'll discuss how ContainerPilot 3 will integrate with the RFD36 "Mariposa" scheduler.

Preview the RFD:

- [Front page](https://github.com/joyent/rfd/blob/rfd86/rfd/0086/README.md)
  - [First-class support for multi-process containers](https://github.com/joyent/rfd/blob/rfd86/rfd/0086/multiprocess.md)
  - [Mariposa integration](https://github.com/joyent/rfd/blob/rfd86/rfd/0086/mariposa.md)
  - [Configuration improvements](https://github.com/joyent/rfd/blob/rfd86/rfd/0086/config.md)
  - [Backwards compatibility and support](https://github.com/joyent/rfd/blob/rfd86/rfd/0086/compat.md)
  - [Consolidate discovery on Consul](https://github.com/joyent/rfd/blob/rfd86/rfd/0086/consul.md)


@jasonpincin @misterbisson 