### PR TITLE
Revisions for ContainerPilot RFD

### DIFF
--- a/rfd/0086/config.md
+++ b/rfd/0086/config.md
@@ -2,9 +2,9 @@
 
 JSON as a configuration language leaves much to be desired. It has no comments, is unforgiving in editing (we've specifically written code in ContainerPilot to point out extraneous trailing commas in the config!). Any configuration language change should also support those users we know who are generating ContainerPilot configurations automatically.
 
-We will abandon JSON in favor of the more human-friendly YAML configuration language. It has a particular advantage for those users who are generating configuration because of the ubiquity of YAML-generating libraries (this is its major advantage over Hashicorp HCL). During ContainerPilot configuration loading, we can check for files in `/etc/containerpilot.d/` (a configurable location via the `-config` flag) and merge them together.
+We will abandon JSON in favor of the more human-friendly YAML configuration language. It has a particular advantage for those users who are generating configuration because of the ubiquity of YAML-generating libraries (this is its major advantage over Hashicorp HCL).
 
-The merging process is as follows:
+The `CONTAINERPILOT` environment variable and `-config` command line flag will no longer support passing in the contents of the configuration file as a string. Instead they will now indicate the directory location for configuration files, with a default value of `/etc/containerpilot.d` (note that we're removing the `file://` prefix as well). During ContainerPilot configuration loading, we can check for files in the config directory and merge them together. The merging process is as follows:
 
 - Lexigraphically sort all the config files.
 - Multiple `service`, `health`, `sensor` blocks are unioned.

--- a/rfd/0086/mariposa.md
+++ b/rfd/0086/mariposa.md
@@ -79,9 +79,9 @@ curl -XPOST \
 
 ##### `MaintenanceMode POST /v3/maintenance/{enable|disable}`
 
-This API allows a hook to toggle ContainerPilot's maintenance mode. This replaces the SIGUSR1 handler from 2.x and behaves identically: when maintenance mode is enabled via the `enable` URL parameter, all health checks are stopped and the discovery backend is sent a message to deregister the services. Requests to `/v3/status` will show all services with `status: "maintenance"`.
+This API allows a hook to toggle ContainerPilot's maintenance mode. This replaces the SIGUSR1 handler from 2.x and behaves identically: when maintenance mode is enabled via the `enable` endpoint, all health checks are stopped and the discovery backend is sent a message to deregister the services. Requests to `/v3/status` will show all services with `status: "maintenance"`.
 
-When the `disable` URL parameter is used, ContainerPilot will exit maintenance mode. Requests to enable or disable maintenance mode are idempotent; requesting `enable` twice enables maintenance mode and does nothing on the second request. This endpoint returns a HTTP200 with a JSON body reporting whether the request was an update.
+When the `disable` endpoint is used, ContainerPilot will exit maintenance mode. Requests to enable or disable maintenance mode are idempotent; requesting `enable` twice enables maintenance mode and does nothing on the second request. This endpoint returns a HTTP200 with a JSON body reporting whether the request was an update.
 
 *Example Request*
 

--- a/rfd/0086/mariposa.md
+++ b/rfd/0086/mariposa.md
@@ -10,7 +10,7 @@ The proposal is in two parts. A read-only endpoint exposing the state of all ser
 
 ##### `GetStatus GET /status`
 
-This API will expose the state of all services associated with this ContainerPilot instance, including their dependencies.
+This API will expose the state of all services associated with this ContainerPilot instance as seen by ContainerPilot. The API endpoint also reports the dependencies of each service.
 
 *Example Response*
 
@@ -77,9 +77,11 @@ curl -XPOST \
     http:/v3/reload
 ```
 
-##### `MaintenanceMode POST /v3/maintenance`
+##### `MaintenanceMode POST /v3/maintenance/{enable|disable}`
 
-This API allows a hook to toggle ContainerPilot's maintenance mode. This replaces the SIGUSR1 handler from 2.x and behaves identically: all health checks are stopped and the discovery backend is sent a message to deregister the services. Making the same request when in maintenance mode causes ContainerPilot to exit maintenance mode. This endpoint returns a HTTP200 with no body.
+This API allows a hook to toggle ContainerPilot's maintenance mode. This replaces the SIGUSR1 handler from 2.x and behaves identically: when maintenance mode is enabled via the `enable` URL parameter, all health checks are stopped and the discovery backend is sent a message to deregister the services. Requests to `/v3/status` will show all services with `status: "maintenance"`.
+
+When the `disable` URL parameter is used, ContainerPilot will exit maintenance mode. Requests to enable or disable maintenance mode are idempotent; requesting `enable` twice enables maintenance mode and does nothing on the second request. This endpoint returns a HTTP200 with a JSON body reporting whether the request was an update.
 
 *Example Request*
 
@@ -87,6 +89,17 @@ This API allows a hook to toggle ContainerPilot's maintenance mode. This replace
 curl -XPOST \
     --unix-socket /var/containerpilot.sock \
     http:/v3/maintenance
+```
+
+*Example Response*
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 21
+{
+  "updated": true
+}
 ```
 
 

--- a/rfd/0086/mariposa.md
+++ b/rfd/0086/mariposa.md
@@ -88,7 +88,7 @@ When the `disable` URL parameter is used, ContainerPilot will exit maintenance m
 ```
 curl -XPOST \
     --unix-socket /var/containerpilot.sock \
-    http:/v3/maintenance
+    http:/v3/maintenance/enable
 ```
 
 *Example Response*


### PR DESCRIPTION
Update ContainerPilot RFD with changes to behavior of `CONTAINERPILOT` env var and `-config` flag as discussed with @geek in https://github.com/joyent/rfd/pull/13#pullrequestreview-23003632

Update ContainerPilot RFD with changes to behavior of maintenance mode API as discussed with @jasonpincin and @geek in https://github.com/joyent/rfd/pull/13#pullrequestreview-23008497