### PR TITLE
RFD86 updates: use json5 and enhance dependency resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ formal writing that it has come to represent.)
 | publish | [RFD 83 Triton `http_proxy` support](./rfd/0083/README.md) |
 | predraft | [RFD 84 Providing Manta access on multiple networks](./rfd/0084/README.md) |
 | draft    | [RFD 85 Tactical improvements for Manta alarms](./rfd/0085/README.md) |
-| predraft | [RFD 86 ContainerPilot 3](./rfd/0086/README.md) |
+| draft | [RFD 86 ContainerPilot 3](./rfd/0086/README.md) |
 | predraft | [RFD 87 Docker Events for Triton](./rfd/0087/README.md) |
 | draft    | [RFD 88 DC and Hardware Management Futures](./rfd/0088/README.md)
 | draft    | [RFD 89 Project Tiresias](./rfd/0089/README.md)

--- a/rfd/0086/config.md
+++ b/rfd/0086/config.md
@@ -31,7 +31,7 @@ For example consider the two JSON5 files below.
   health: [
     {
       name: "checkA",
-      service: "nginx"
+      job: "nginx"
       exec: "curl -s --fail localhost/health"
     }
   ]
@@ -58,7 +58,7 @@ For example consider the two JSON5 files below.
   health: [
     {
       name: "checkB",
-      service: "nginx"
+      job: "nginx"
       exec: "curl -s --fail localhost/otherhealth"
     }
   ]
@@ -89,12 +89,12 @@ These will be merged as follows:
   health: [
     {
       name: "checkA",
-      service: "nginx"
+      job: "nginx"
       exec: "curl -s --fail localhost/health"
     },
     {
       name: "checkB",
-      service: "nginx"
+      job: "nginx"
       exec: "curl -s --fail localhost/otherhealth"
     }
   ]
@@ -121,7 +121,11 @@ The full example configuration for ContainerPilot found in the existing docs wou
       // this is upstart-like syntax indicating we want to start this
       // service when the "setup" service has exited with success but
       // give up after 60 sec
-      when: "setup exitSuccess timeout 60s",
+      when: {
+          source: "setup",
+          event: "exitSuccess",
+          timeout: "60s"
+      },
       exec: "/bin/app",
       restart: "never",
       port: 80,
@@ -147,19 +151,28 @@ The full example configuration for ContainerPilot found in the existing docs wou
     {
       name: "setup",
       // we can create a chain of "prestart" events
-      when: "consul-agent healthy",
+      when: {
+          source: "consul-agent",
+          event: "healthy"
+      },
       exec: "/usr/local/bin/preStart-script.sh",
       restart: "never"
     },
     {
       name: "preStop",
-      when: "app stopping",
+      when: {
+          source: "app",
+          event: "stopping"
+      },
       exec: "/usr/local/bin/preStop-script.sh",
       restart: "never",
     },
     {
       name: "postStop",
-      when: "app stopped",
+      when: {
+          source: "app",
+          event: "stopped"
+      },
       exec: "/usr/local/bin/postStop-script.sh",
     },
     {
@@ -197,7 +210,7 @@ The full example configuration for ContainerPilot found in the existing docs wou
   health: {
     {
       name: "checkA",
-      service: "nginx",
+      job: "nginx",
       exec: "/usr/bin/curl --fail -s -o /dev/null http://localhost/app",
       poll: 5,
       timeout: "5s",

--- a/rfd/0086/config.md
+++ b/rfd/0086/config.md
@@ -118,9 +118,8 @@ The full example configuration for ContainerPilot found in the existing docs wou
   jobs: [
     {
       name: "app",
-      // this is upstart-like syntax indicating we want to start this
-      // service when the "setup" service has exited with success but
-      // give up after 60 sec
+      // we want to start this job when the "setup" job has exited
+      // with success but give up after 60 sec
       when: {
           source: "setup",
           event: "exitSuccess",

--- a/rfd/0086/config.md
+++ b/rfd/0086/config.md
@@ -215,6 +215,7 @@ The full example configuration for ContainerPilot found in the existing docs wou
       timeout: "5s",
     }
   }
+  // see "multiprocess.md" for more details on this section
   watches: {
     {
       name: "app",
@@ -228,6 +229,7 @@ The full example configuration for ContainerPilot found in the existing docs wou
     }
   },
   control: {
+    // see "mariposa.md" for details on this section
     socket: "/var/run/containerpilot.socket"
   },
   telemetry: {

--- a/rfd/0086/config.md
+++ b/rfd/0086/config.md
@@ -2,7 +2,7 @@
 
 JSON as a configuration language leaves much to be desired. It has no comments, is unforgiving in editing (we've specifically written code in ContainerPilot to point out extraneous trailing commas in the config!). Any configuration language change should also support those users we know who are generating ContainerPilot configurations automatically.
 
-We will abandon JSON in favor of the more human-friendly YAML configuration language. It has a particular advantage for those users who are generating configuration because of the ubiquity of YAML-generating libraries (this is its major advantage over Hashicorp HCL).
+We will abandon JSON in favor of the somewhat more human-friendly [JSON5](https://github.com/json5/json5) configuration language. It has a particular advantage for those users who are generating configuration because JSON documents are valid JSON5 documents. YAML and [Hashicorp's HCL](https://github.com/hashicorp/hcl) were possible alternatives but feedback from the community and resulted in pushback on both due to either difficulty of correctly hand-writing (in the case of YAML) or lack of library support (in the case of HCL).
 
 The `CONTAINERPILOT` environment variable and `-config` command line flag will no longer support passing in the contents of the configuration file as a string. Instead they will now indicate the directory location for configuration files, with a default value of `/etc/containerpilot.d` (note that we're removing the `file://` prefix as well). During ContainerPilot configuration loading, we can check for files in the config directory and merge them together. The merging process is as follows:
 
@@ -10,166 +10,220 @@ The `CONTAINERPILOT` environment variable and `-config` command line flag will n
 - Multiple `service`, `health`, `sensor` blocks are unioned.
 - Keys with the same name replace those that occurred previously.
 
-For example consider the two YAML files below.
+For example consider the two JSON5 files below.
 
-1.yml
+1.json5
+```json5
+{
+  consul: {
+    host: "localhost:8500"
+  },
+  services: [
+    {
+      name: "nginx",
+      port: 80
+    },
+    {
+      name: "appA",
+      port: 8000
+    }
+  ],
+  health: [
+    {
+      name: "checkA",
+      service: "nginx"
+      exec: "curl -s --fail localhost/health"
+    }
+  ]
+}
 ```
-consul:
-  host: localhost:8500
 
-services:
-  nginx:
-    port: 80
 
-  app-A:
-    port: 8000
-
-health:
-  nginx:
-    check-A:
-      command: curl -s --fail localhost/health
-
-```
-
-2.yml
-```
-consul:
-  host: consul.svc.triton.zone
-
-services:
-  app-A:
-    port: 9000
-
-  app-B:
-    port: 8000
-
-health:
-  nginx:
-    check-B:
-      command: curl -s --fail localhost/otherhealth
-
+2.json5
+```json5
+{
+  consul: {
+    host: "consul.svc.triton.zone:8500"
+  },
+  services: [
+    {
+      name: "appA",
+      port: 9000
+    },
+    {
+      name: "appB",
+      port: 8000
+    }
+  ],
+  health: [
+    {
+      name: "checkB",
+      service: "nginx"
+      exec: "curl -s --fail localhost/otherhealth"
+    }
+  ]
+}
 ```
 
 These will be merged as follows:
 
-```
-consul:
-  host: consul.svc.triton.zone
-
-services:
-  nginx:
-    port: 80
-
-  app-A:
-    port: 9000
-
-  app-B:
-    port: 8000
-
-health:
-  nginx:
-    check-A:
-      command: curl -s --fail localhost/health
-    check-B:
-      command: curl -s --fail localhost/otherhealth
-
+```json5
+{
+  consul: {
+    host: "consul.svc.triton.zone:8500"
+  },
+  services: [
+    {
+      name: "nginx",
+      port: 80
+    },
+    {
+      name: "appA",
+      port: 9000
+    },
+    {
+      name: "appB",
+      port: 8000
+    }
+  ],
+  health: [
+    {
+      name: "checkA",
+      service: "nginx"
+      exec: "curl -s --fail localhost/health"
+    },
+    {
+      name: "checkB",
+      service: "nginx"
+      exec: "curl -s --fail localhost/otherhealth"
+    }
+  ]
+}
 ```
 
 
 The full example configuration for ContainerPilot found in the existing docs would look like the following:
 
 
-```
-consul:
-  host: localhost:8500
-
-logging:
-  level: INFO
-  format: default
-  output: stdout
-
-service:
-  app:
-    port: 80
-    heartbeat: 5
-    tll: 10
-    tags:
-    - app
-    - prod
-    interfaces:
-    - eth0
-    - eth1[1]
-    - 192.168.0.0/16
-    - 2001:db8::/64
-    - eth2:inet
-    - eth2:inet6
-    - inet
-    - inet6
-    - static:192.168.1.100"
-
-    stopTimeout: 5
-    preStop: /usr/local/bin/preStop-script.sh
-    postStop: /usr/local/bin/postStop-script.sh
-
-    depends:
-      setup:
-        wait: success
-      nginx:
-        onChange: /usr/local/bin/reload-nginx.sh
-        poll: 30
-        timeout: "30s"
-      consul-agent:
-        wait: healthy
-      app:
-        onChange: /usr/local/bin/reload-app.sh
-        poll: 10
-        timeout: "10s"
-
-  setup:
-    command: /usr/local/bin/preStart-script.sh {{.ENV_VAR_NAME}}
-    advertise: false
-    restart: never
-
-  consul-agent:
-    port: 8500
-    command: consul -agent -join consul
-    advertise: false
-    restart: always
-
-  consul-template:
-    command: >
-      consul-template -consul consul
-          -template /tmp/template.ctmpl:/tmp/result
-    advertise: false
-    restart: always
-
-  task1:
-    command: /usr/local/bin/tash.sh arg1
-    frequency: 1500ms
-    timeout: 100ms
-    advertise: false
-
-
-health:
-  nginx:
-    check-A:
-      command: >
-        /usr/bin/curl --fail -s -o /dev/null http://localhost/app
+```json5
+{
+  consul: {
+    host: "localhost:8500"
+  },
+  logging: {
+    level: "INFO",
+    format: "default",
+    output: "stdout"
+  },
+  services: [
+    {
+      name: "app",
+      // this is upstart-like syntax indicating we want to start this
+      // service when the "setup" service has exited with success but
+      // give up after 60 sec
+      start: "exitSuccess setup timeout 60s",
+      exec: "/bin/app",
+      restart: "never",
+      port: 80,
+      heartbeat: 5,
+      tll: 10,
+      stopTimeout: 5,
+      tags: [
+        "app",
+        "prod"
+      ],
+      interfaces: [
+        "eth0",
+        "eth1[1]",
+        "192.168.0.0/16",
+        "2001:db8::/64",
+        "eth2:inet",
+        "eth2:inet6",
+        "inet",
+        "inet6",
+        "static:192.168.1.100", // a trailing comma isn't an error!
+        ]
+    },
+    {
+      name: "setup",
+      // we can create a chain of "prestart" events
+      start: "onStarted consul-agent",
+      exec: "/usr/local/bin/preStart-script.sh",
+      restart: "never"
+    },
+    {
+      name: "preStop",
+      start: "onStopping app",
+      exec: "/usr/local/bin/preStop-script.sh",
+      restart: "never",
+    },
+    {
+      name: "postStop",
+      start: "onStopped app",
+      exec: "/usr/local/bin/postStop-script.sh",
+    },
+    {
+      // a service that doesn't have a start block starts up on the
+      // global "onStartup" event by default
+      name: "consul-agent",
+      // note we don't have a port here because we don't intend to
+      // advertise one to the service discovery backend
+      exec: "consul -agent -join consul",
+      restart: "always"
+    },
+    {
+      name: "consul-template",
+      exec: ["consul-template", "-consul", "consul",
+             "-template", "/tmp/template.ctmpl:/tmp/result"],
+      restart: "always",
+    },
+    {
+      name: "task1",
+      exec: "/usr/local/bin/tash.sh arg1",
+      frequency: "1500ms",
+      timeout: "100ms",
+    }
+  ],
+  health: {
+    {
+      name: "checkA",
+      service: "nginx",
+      exec: "/usr/bin/curl --fail -s -o /dev/null http://localhost/app",
+      poll: 5,
+      timeout: "5s",
+    }
+  }
+  watches: {
+    {
+      name: "app",
+      exec: "/usr/local/bin/reload-app.sh",
+      poll: 10,
+      timeout: "10s"
+    },
+    {
+      name: "nginx",
+      exec: "/usr/local/bin/reload-nginx.sh",
+      poll: 30,
+      timeout: "30s",
+    }
+  },
+  control: {
+    socket: "/var/run/containerpilot.socket"
+  },
+  telemetry: {
+    port: 9090,
+    interfaces: "eth0"
+  },
+  sensors: [
+    {
+      name: "metric_id"
+      help: "help text"
+      type: "counter"
       poll: 5
-      timeout: "5s"
-
-telemetry:
-  port: 9090
-  interfaces:
-  - eth0
-
-sensor:
-  name: metric_id
-  help: help text
-  type: counter
-  poll: 5
-  check: /usr/local/bin/sensor.sh
-
+      exec: "/usr/local/bin/sensor.sh"
+    }
+  ]
+}
 ```
 
 _Related GitHub issues:_

--- a/rfd/0086/multiprocess.md
+++ b/rfd/0086/multiprocess.md
@@ -134,9 +134,9 @@ ContainerPilot hasn't eliminated the complexity of dependency management -- that
 
 That being said, a more expressive configuration of event handlers may more gracefully handle all the above situations and reduce the end-user confusion. Rather than surfacing just changes to dependency membership lists, we'll expose changes to the overall state as ContainerPilot sees it.
 
-ContainerPilot will provide events and each service can opt-in to having a `when` condition on one of these events. Because the life-cycle of each service triggers new events, the user can create a dependency chain among all the services in a container (and their external dependencies). This effectively replaces the `preStart`, `preStop`, and `postStop` behaviors.
+ContainerPilot will provide events and each service can opt-in to starting on a `when` condition on one of these events. Because the life-cycle of each service triggers new events, the user can create a dependency chain among all the services in a container (and their external dependencies). This effectively replaces the `preStart`, `preStop`, and `postStop` behaviors.
 
-ContainerPilot will generate events for all jobs internally, but the user can create a `watch` to query service discovery periodicially and generate `changed` events. This replaces the existing `backends` feature, except that `watches` don't fire their own executables. Instead the user should create a job that watches for events that the `watch` fires.
+ContainerPilot will generate events for all jobs internally, but the user can create a `watch` to query service discovery periodicially and generate `changed` events. This replaces the existing `backends` feature, except that `watches` don't fire their own executables. Instead the user should create a job that watches for events that the `watch` fires. A `watch` event source will be named `"watch.<watch name>"` to differentiate it from job events with the same name.
 
 The configuration for `when` includes an `event`, a sometimes-optional `source`, and an optional `timeout`.
 


### PR DESCRIPTION
These changes follow discussion at last week's meetings around [RFD36](https://github.com/joyent/rfd/tree/master/rfd/0036) and friends, as well as the previous week's work on multi-process support and some of the discoveries along the way of implementing that.

In this PR:
- following a lot of negative reaction to YAML, I've changed the config language update to use JSON5
- removed explicit "non-advertise" clause because we get that for free just by omitting the info required to register with Consul (i.e. the `port`)
- removed the clunky "depends" arrays in lieu of a nicer upstart-like syntax which will be more flexible for us in future development
- pulled `watches` out into their own config section because the external services we're watching and the events that services are waiting for are actually separate concerns -- we can respond to either internal services or external ones.

The big conceptual change is the realization that by merging all the various service/prestart/task/coprocess together, that we have non-advertised services for which we want to respond to events inside the same container. We might want to be able to health check the Consul agent without advertising it, for example.

~~One item I'd like to discuss again is whether "services" is the right word for the config now. It includes periodic tasks, non-advertised processes, and prestart/poststop/etc. The term is also overloaded with "services" as Consul sees them and "services" as an RFD36 scheduler might see them.~~ (resolved in 4bea5a4)

cc @jasonpincin @misterbisson @geek 