### PR TITLE
Add a prototype for asciidoc

### DIFF
--- a/prototypes/front-matter.adoc
+++ b/prototypes/front-matter.adoc
@@ -1,0 +1,24 @@
+:revremark: State: {state}
+:attribute-missing: warn
+:docinfo:
+:doctype: article
+:hide-uri-scheme:
+:icons: font
+:idprefix:
+:idseparator: -
+:numbered:
+:sectanchors:
+:sectlinks:
+:sectnums:
+:sectnumlevels: 1
+:showtitle:
+:source-highlighter: pygments
+:toc: left
+:xrefstyle: full
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]

--- a/prototypes/prototype.adoc
+++ b/prototypes/prototype.adoc
@@ -6,6 +6,7 @@ state: predraft
 :author: Han Solo <han@example.com>; Frodo Baggins <frodo@example.com>
 :state: predraft
 :revremark: State: {state}
+:attribute-missing: warn
 :docinfo:
 :doctype: article
 :icons: font

--- a/prototypes/prototype.adoc
+++ b/prototypes/prototype.adoc
@@ -1,0 +1,18 @@
+:author: Han Solo <han@example.com>; Frodo Baggins <frodo@example.com>
+:revremark: State: predraft
+
+:showtitle:
+:toc: left
+:numbered:
+:icons: font
+
+////
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    Copyright 2017 <contribution>
+////
+
+
+# RFD <Number> <Title>

--- a/prototypes/prototype.adoc
+++ b/prototypes/prototype.adoc
@@ -1,11 +1,23 @@
+---
+authors: Han Solo <han@example.com>, Frodo Baggins <frodo@example.com>
+state: predraft
+---
 :author: Han Solo <han@example.com>; Frodo Baggins <frodo@example.com>
 :state: predraft
 :revremark: State: {state}
-
-:showtitle:
-:toc: left
-:numbered:
+:docinfo:
+:doctype: article
 :icons: font
+:idprefix:
+:numbered:
+:sectanchors:
+:sectlinks:
+:sectnums:
+:sectnumlevels: 2
+:showtitle:
+:source-highlighter: pygments
+:skip-front-matter:
+:toc: left
 
 ////
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/prototypes/prototype.adoc
+++ b/prototypes/prototype.adoc
@@ -5,32 +5,9 @@ state: predraft
 = RFD <NUMBER> <Title>
 :author: Han Solo <han@example.com>; Frodo Baggins <frodo@example.com>
 :state: predraft
-:revremark: State: {state}
-:attribute-missing: warn
-:docinfo:
-:doctype: article
-:hide-uri-scheme:
-:icons: font
-:idprefix:
-:idseparator: -
-:keywords: rfd, rfd <NUMBER, prototype, sample, keywords
-:numbered:
 :revnumber: 0.1.0
-:sectanchors:
-:sectlinks:
-:sectnums:
-:sectnumlevels: 2
-:showtitle:
-:source-highlighter: pygments
-:toc: left
-:xrefstyle: full
-ifdef::env-github[]
-:tip-caption: :bulb:
-:note-caption: :information_source:
-:important-caption: :heavy_exclamation_mark:
-:caution-caption: :fire:
-:warning-caption: :warning:
-endif::[]
+:keywords: rfd <NUMBER>, prototype, sample, keywords
+include::front-matter.adoc[]
 
 ////
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/prototypes/prototype.adoc
+++ b/prototypes/prototype.adoc
@@ -1,5 +1,6 @@
 :author: Han Solo <han@example.com>; Frodo Baggins <frodo@example.com>
-:revremark: State: predraft
+:state: predraft
+:revremark: State: {state}
 
 :showtitle:
 :toc: left
@@ -13,6 +14,5 @@
 
     Copyright 2017 <contribution>
 ////
-
 
 # RFD <Number> <Title>

--- a/prototypes/prototype.adoc
+++ b/prototypes/prototype.adoc
@@ -2,6 +2,7 @@
 authors: Han Solo <han@example.com>, Frodo Baggins <frodo@example.com>
 state: predraft
 ---
+= RFD <NUMBER> <Title>
 :author: Han Solo <han@example.com>; Frodo Baggins <frodo@example.com>
 :state: predraft
 :revremark: State: {state}
@@ -16,7 +17,6 @@ state: predraft
 :sectnumlevels: 2
 :showtitle:
 :source-highlighter: pygments
-:skip-front-matter:
 :toc: left
 
 ////
@@ -27,4 +27,5 @@ state: predraft
     Copyright 2017 <contribution>
 ////
 
-# RFD <Number> <Title>
+[[introduction]]
+== Introduction

--- a/prototypes/prototype.adoc
+++ b/prototypes/prototype.adoc
@@ -24,6 +24,13 @@ state: predraft
 :source-highlighter: pygments
 :toc: left
 :xrefstyle: full
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 ////
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/prototypes/prototype.adoc
+++ b/prototypes/prototype.adoc
@@ -9,9 +9,13 @@ state: predraft
 :attribute-missing: warn
 :docinfo:
 :doctype: article
+:hide-uri-scheme:
 :icons: font
 :idprefix:
+:idseparator: -
+:keywords: rfd, rfd <NUMBER, prototype, sample, keywords
 :numbered:
+:revnumber: 0.1.0
 :sectanchors:
 :sectlinks:
 :sectnums:
@@ -19,6 +23,7 @@ state: predraft
 :showtitle:
 :source-highlighter: pygments
 :toc: left
+:xrefstyle: full
 
 ////
     This Source Code Form is subject to the terms of the Mozilla Public


### PR DESCRIPTION
@arekinath , can you give this a quick once over w/ your tooling.  I had to go digging into the spec to see how multiple authors are supported (semicolon delimited list), but I don't know how the missing `:email:` attribute will impact things (or if that should also be a semicolon delimited list).

Feel free to merge if you approve.